### PR TITLE
[Refacot] TransactionStatus 필드를 조회 response에 추가

### DIFF
--- a/src/main/java/com/yzgeneration/evc/domain/useditem/dto/UsedItemResponse.java
+++ b/src/main/java/com/yzgeneration/evc/domain/useditem/dto/UsedItemResponse.java
@@ -46,6 +46,8 @@ public class UsedItemResponse {
 
         private TransactionMode transactionMode;
 
+        private TransactionStatue transactionStatue;
+
         private List<String> imageURLs;
 
         private int likeCount;

--- a/src/main/java/com/yzgeneration/evc/domain/useditem/service/UsedItemService.java
+++ b/src/main/java/com/yzgeneration/evc/domain/useditem/service/UsedItemService.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -26,7 +25,7 @@ public class UsedItemService {
     private final UsedItemLoader usedItemLoader;
     private final UsedItemImageLoader usedItemImageLoader;
 
-    public CreateUsedItemResponse createUsedItem(CreateUsedItemRequest createUsedItemRequest, List<MultipartFile> imageFiles) throws IOException {
+    public CreateUsedItemResponse createUsedItem(CreateUsedItemRequest createUsedItemRequest, List<MultipartFile> imageFiles) {
         UsedItem usedItem = usedItemAppender.createUsedItem(createUsedItemRequest);
         usedItemImageAppender.createUsedItemImages(usedItem.getId(), imageFiles);
 
@@ -43,6 +42,7 @@ public class UsedItemService {
                         .title(usedItem.getItemDetails().getTitle())
                         .price(usedItem.getItemDetails().getPrice())
                         .transactionMode(usedItem.getUsedItemTransaction().getTransactionMode())
+                        .transactionStatue(usedItem.getUsedItemTransaction().getTransactionStatue())
                         .imageURLs(usedItemImageLoader.loadUsedItemImages(usedItem.getId()))
                         .likeCount(usedItem.getItemStats().getLikeCount())
                         .createAt(usedItem.getCreatedAt())

--- a/src/test/java/com/yzgeneration/evc/docs/usedItem/UsedItemControllerDocsTest.java
+++ b/src/test/java/com/yzgeneration/evc/docs/usedItem/UsedItemControllerDocsTest.java
@@ -140,6 +140,8 @@ public class UsedItemControllerDocsTest extends RestDocsSupport {
                                         .description("중고상품 가격"),
                                 fieldWithPath("loadUsedItemDetails[].transactionMode").type(JsonFieldType.STRING)
                                         .description("중고상품 거래방법 (SELL, BUY, AUCTION)"),
+                                fieldWithPath("loadUsedItemDetails[].transactionStatus").type(JsonFieldType.STRING)
+                                        .description("중고상품 거래방법 (ONGOING, RESERVE, COMPLETE)"),
                                 fieldWithPath("loadUsedItemDetails[].imageURLs").type(JsonFieldType.ARRAY)
                                         .description("중고상품 이미지 리스트"),
                                 fieldWithPath("loadUsedItemDetails[].likeCount").type(JsonFieldType.NUMBER)


### PR DESCRIPTION
### 🔅 이슈번호
close #114 

---

### ⏰ 작업한 내용
- 중고상품 전체 조회 response에 TransactionStatus 값 추가

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/9b06e4a1-96d3-4bc3-affb-87e1bb248899)
<i>중고상품들 조회 response에 TransactionStatus 추가</i>