### PR TITLE
[Refactor/#159] 상품 이미지에 대한 presignedURL API의 request값 변경

### DIFF
--- a/src/main/java/com/yzgeneration/evc/domain/image/controller/PresignedUrlController.java
+++ b/src/main/java/com/yzgeneration/evc/domain/image/controller/PresignedUrlController.java
@@ -1,11 +1,10 @@
 package com.yzgeneration.evc.domain.image.controller;
 
+import com.yzgeneration.evc.domain.image.dto.ImageRequest;
 import com.yzgeneration.evc.domain.image.dto.ImageResponse;
 import com.yzgeneration.evc.domain.image.service.PresignedUrlService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -16,8 +15,8 @@ public class PresignedUrlController {
     private final PresignedUrlService presignedUrlService;
 
     @PostMapping
-    public List<ImageResponse> createPresignedURL(@RequestParam String prefix, @RequestPart List<String> imageNames) {
-        return presignedUrlService.generatePresignedURL(prefix, imageNames);
+    public List<ImageResponse> createPresignedURL(@RequestBody ImageRequest imageRequest) {
+        return presignedUrlService.generatePresignedURL(imageRequest);
     }
 
     @PostMapping("/profile")

--- a/src/main/java/com/yzgeneration/evc/domain/image/controller/PresignedUrlController.java
+++ b/src/main/java/com/yzgeneration/evc/domain/image/controller/PresignedUrlController.java
@@ -15,9 +15,9 @@ import java.util.List;
 public class PresignedUrlController {
     private final PresignedUrlService presignedUrlService;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public List<ImageResponse> createPresignedURL(@RequestParam String prefix, @RequestPart List<MultipartFile> imageFiles) {
-        return presignedUrlService.generatePresignedURL(prefix, imageFiles);
+    @PostMapping
+    public List<ImageResponse> createPresignedURL(@RequestParam String prefix, @RequestPart List<String> imageNames) {
+        return presignedUrlService.generatePresignedURL(prefix, imageNames);
     }
 
     @PostMapping("/profile")

--- a/src/main/java/com/yzgeneration/evc/domain/image/dto/ImageRequest.java
+++ b/src/main/java/com/yzgeneration/evc/domain/image/dto/ImageRequest.java
@@ -1,0 +1,13 @@
+package com.yzgeneration.evc.domain.image.dto;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ImageRequest {
+    String prefix;
+
+    List<String> imageNames = new ArrayList<>();
+}

--- a/src/main/java/com/yzgeneration/evc/domain/image/service/PresignedUrlService.java
+++ b/src/main/java/com/yzgeneration/evc/domain/image/service/PresignedUrlService.java
@@ -4,7 +4,6 @@ import com.yzgeneration.evc.domain.image.dto.ImageResponse;
 import com.yzgeneration.evc.domain.image.implement.ImageHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -13,13 +12,13 @@ import java.util.List;
 public class PresignedUrlService {
     private final ImageHandler imageHandler;
 
-    public List<ImageResponse> generatePresignedURL(String prefix, List<MultipartFile> imageFiles) {
-        return imageFiles.stream().map(imageFile ->
-                imageHandler.getPresignedURLForUpload(prefix, imageFile.getOriginalFilename())
+    public List<ImageResponse> generatePresignedURL(String prefix, List<String> imageNames) {
+        return imageNames.stream().map(imageName ->
+                imageHandler.getPresignedURLForUpload(prefix, imageName)
         ).toList();
     }
 
     public ImageResponse generateForProfile(String fileName) {
-        return imageHandler.getPresignedURLForUpload("profile",fileName);
+        return imageHandler.getPresignedURLForUpload("profile", fileName);
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/image/service/PresignedUrlService.java
+++ b/src/main/java/com/yzgeneration/evc/domain/image/service/PresignedUrlService.java
@@ -1,5 +1,6 @@
 package com.yzgeneration.evc.domain.image.service;
 
+import com.yzgeneration.evc.domain.image.dto.ImageRequest;
 import com.yzgeneration.evc.domain.image.dto.ImageResponse;
 import com.yzgeneration.evc.domain.image.implement.ImageHandler;
 import lombok.RequiredArgsConstructor;
@@ -12,8 +13,9 @@ import java.util.List;
 public class PresignedUrlService {
     private final ImageHandler imageHandler;
 
-    public List<ImageResponse> generatePresignedURL(String prefix, List<String> imageNames) {
-        return imageNames.stream().map(imageName ->
+    public List<ImageResponse> generatePresignedURL(ImageRequest imageRequest) {
+        String prefix = imageRequest.getPrefix();
+        return imageRequest.getImageNames().stream().map(imageName ->
                 imageHandler.getPresignedURLForUpload(prefix, imageName)
         ).toList();
     }

--- a/src/test/java/com/yzgeneration/evc/docs/image/PresignedUrlControllerDocsTest.java
+++ b/src/test/java/com/yzgeneration/evc/docs/image/PresignedUrlControllerDocsTest.java
@@ -2,10 +2,9 @@ package com.yzgeneration.evc.docs.image;
 
 import com.yzgeneration.evc.docs.RestDocsSupport;
 import com.yzgeneration.evc.domain.image.controller.PresignedUrlController;
+import com.yzgeneration.evc.domain.image.dto.ImageRequest;
 import com.yzgeneration.evc.domain.image.dto.ImageResponse;
 import com.yzgeneration.evc.domain.image.service.PresignedUrlService;
-
-import com.yzgeneration.evc.mock.image.MockUsedItemImageFile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -14,15 +13,16 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static com.yzgeneration.evc.fixture.ImageFixture.fixImageRequest;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -38,32 +38,30 @@ public class PresignedUrlControllerDocsTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("이미지 저장을 위한 presigned url 생성")
-    void createPresignedURL() throws Exception {
-        ImageResponse imageResponse1 = ImageResponse.builder()
-                .presignedURL("http://localhost:8080/image/1234.jpg")
-                .imageName("1234.jpg")
-                .build();
-        ImageResponse imageResponse2 = ImageResponse.builder()
-                .presignedURL("http://localhost:8080/image/5678.jpg")
-                .imageName("5678.jpg")
+    @DisplayName("아이템 이미지 저장을 위한 presigned url 생성")
+    void createForItem() throws Exception {
+
+        ImageRequest imageRequest = fixImageRequest();
+        ImageResponse imageResponse = ImageResponse.builder()
+                .presignedURL("http://localhost:8080/presignedURL")
+                .imageName("imageName.jpg")
                 .build();
 
-        when(presignedUrlService.generatePresignedURL(anyString(), anyList())).thenReturn(List.of(imageResponse1, imageResponse2));
+        when(presignedUrlService.generatePresignedURL(any()))
+                .thenReturn(List.of(imageResponse));
 
-        mockMvc.perform(MockMvcRequestBuilders
-                        .multipart("/api/images")
-                        .file("imageFiles", new MockUsedItemImageFile().getImageFiles().get(0).getBytes())
-                        .file("imageFiles", new MockUsedItemImageFile().getImageFiles().get(1).getBytes())
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/images")
                         .with(csrf())
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .queryParam("prefix", "prefix-name"))
+                        .content(objectMapper.writeValueAsString(imageRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(document("image-presignedURL-create",
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
-                                queryParameters(parameterWithName("prefix").description("이미지 경로 (useditem, auction, chat)")),
-                                requestParts(partWithName("imageFiles").description("업로드할 이미지 list")),
+                                requestFields(
+                                        fieldWithPath("prefix").type(JsonFieldType.STRING).description("이미지 경로 (useditem, auction, chat)"),
+                                        fieldWithPath("imageNames").type(JsonFieldType.ARRAY).description("업로드할 이미지 이름 list")
+                                ),
                                 responseFields(
                                         fieldWithPath("[]").type(JsonFieldType.ARRAY)
                                                 .description("생성된 presigned url 리스트"),

--- a/src/test/java/com/yzgeneration/evc/fixture/ImageFixture.java
+++ b/src/test/java/com/yzgeneration/evc/fixture/ImageFixture.java
@@ -1,0 +1,16 @@
+package com.yzgeneration.evc.fixture;
+
+import com.yzgeneration.evc.domain.image.dto.ImageRequest;
+
+import java.util.List;
+
+import static com.yzgeneration.evc.fixture.Fixture.fixtureMonkey;
+
+public class ImageFixture {
+    public static ImageRequest fixImageRequest() {
+        return fixtureMonkey.giveMeBuilder(ImageRequest.class)
+                .set("prefix", "prefix")
+                .set("imageNames", List.of("imageName.jpg"))
+                .sample();
+    }
+}

--- a/src/test/java/com/yzgeneration/evc/fixture/UsedItemFixture.java
+++ b/src/test/java/com/yzgeneration/evc/fixture/UsedItemFixture.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import static com.yzgeneration.evc.fixture.Fixture.fixtureMonkey;
 
-public abstract class UsedItemFixture {
+public class UsedItemFixture {
 
     public static CreateUsedItemRequest fixCreateUsedItemRequest() {
         return fixtureMonkey.giveMeBuilder(CreateUsedItemRequest.class)

--- a/src/test/java/com/yzgeneration/evc/image/PresignedUrlControllerTest.java
+++ b/src/test/java/com/yzgeneration/evc/image/PresignedUrlControllerTest.java
@@ -2,6 +2,7 @@ package com.yzgeneration.evc.image;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yzgeneration.evc.domain.image.controller.PresignedUrlController;
+import com.yzgeneration.evc.domain.image.dto.ImageRequest;
 import com.yzgeneration.evc.domain.image.dto.ImageResponse;
 import com.yzgeneration.evc.domain.image.service.PresignedUrlService;
 import com.yzgeneration.evc.mock.WithFakeUser;
@@ -11,14 +12,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import java.util.List;
+
+import static com.yzgeneration.evc.fixture.ImageFixture.fixImageRequest;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -39,14 +46,34 @@ class PresignedUrlControllerTest {
 
     @Test
     @WithFakeUser
+    @DisplayName("중고상품 및 경매상품을 위한 presignedURL")
+    void createForItem() throws Exception {
+
+        ImageRequest imageRequest = fixImageRequest();
+
+        when(presignedUrlService.generatePresignedURL(any()))
+                .thenReturn(List.of(ImageResponse.builder().presignedURL("https://www.abc.com").imageName("imageName.jpg").build()));
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/images")
+                        .content(objectMapper.writeValueAsString(imageRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].presignedURL").value("https://www.abc.com"))
+                .andExpect(jsonPath("$[0].imageName").value("imageName.jpg"));
+    }
+
+    @Test
+    @WithFakeUser
     @DisplayName("프로필사진을 위한 presignedUrl을 생성한다.")
     void createForProfile() throws Exception {
         given(presignedUrlService.generateForProfile(any()))
                 .willReturn(ImageResponse.builder().presignedURL("https://www.abc.com").imageName("profile/abc-abc.jpg").build());
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/images/profile")
-                .queryParam("imageName", "profile/abc-abc.jpg")
-                .with(csrf()))
+                        .queryParam("imageName", "profile/abc-abc.jpg")
+                        .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.presignedURL").value("https://www.abc.com"))
                 .andExpect(jsonPath("$.imageName").value("profile/abc-abc.jpg"));


### PR DESCRIPTION
### 🔅 이슈번호
close #159 

---

### ⏰ 작업한 내용
- 중고상품 및 경매상품 이미지에 대한 presignedURL API의 request값 변경 (List<Multipartfile> -> List<String>)

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/533a6733-5d8a-4889-acab-00085d295b2e)
<i>image controller request(이태릭체 그대로하기)</i>