### PR TITLE
[Feat/#201] 상품의 거래 상태 수정 및 삭제 기능 추가

### DIFF
--- a/src/docs/asciidoc/auctionitem/auctionitem.adoc
+++ b/src/docs/asciidoc/auctionitem/auctionitem.adoc
@@ -42,3 +42,14 @@ include::{snippets}/auctionitems-search/query-parameters.adoc[]
 === HTTP Response
 include::{snippets}/auctionitems-search/http-response.adoc[]
 include::{snippets}/auctionitems-search/response-fields.adoc[]
+
+[[auctionitem-delete]]
+== 경매상품 삭제
+
+=== HTTP Request
+include::{snippets}/auctionitem-delete/http-request.adoc[]
+include::{snippets}/auctionitem-delete/path-parameters.adoc[]
+
+=== HTTP Response
+include::{snippets}/auctionitem-delete/http-response.adoc[]
+include::{snippets}/auctionitem-delete/response-fields.adoc[]

--- a/src/docs/asciidoc/usedItem/usedItem.adoc
+++ b/src/docs/asciidoc/usedItem/usedItem.adoc
@@ -42,3 +42,26 @@ include::{snippets}/usedItems-search/query-parameters.adoc[]
 === HTTP Response
 include::{snippets}/usedItems-search/http-response.adoc[]
 include::{snippets}/usedItems-search/response-fields.adoc[]
+
+[[usedItem-transactionstatus-update]]
+== 중고상품 거래 상태 수정
+
+=== HTTP Request
+include::{snippets}/usedItem-transactionstatus-update/http-request.adoc[]
+include::{snippets}/useditem-transactionstatus-update/path-parameters.adoc[]
+include::{snippets}/usedItem-transactionstatus-update/query-parameters.adoc[]
+
+=== HTTP Response
+include::{snippets}/usedItem-transactionstatus-update/http-response.adoc[]
+include::{snippets}/usedItem-transactionstatus-update/response-fields.adoc[]
+
+[[useditem-delete]]
+== 중고상품 삭제
+
+=== HTTP Request
+include::{snippets}/useditem-delete/http-request.adoc[]
+include::{snippets}/useditem-delete/path-parameters.adoc[]
+
+=== HTTP Response
+include::{snippets}/useditem-delete/http-response.adoc[]
+include::{snippets}/useditem-delete/response-fields.adoc[]

--- a/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/controller/AuctionItemController.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/controller/AuctionItemController.java
@@ -2,9 +2,9 @@ package com.yzgeneration.evc.domain.item.auctionitem.controller;
 
 import com.yzgeneration.evc.common.dto.CommonResponse;
 import com.yzgeneration.evc.common.dto.SliceResponse;
-import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemRequest.CreateAuctionItemRequest;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemResponse.GetAuctionItemResponse;
+import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.service.AuctionItemService;
 import com.yzgeneration.evc.security.MemberPrincipal;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +38,11 @@ public class AuctionItemController {
     @GetMapping("/search")
     public SliceResponse<GetAuctionItemsResponse> searchAuctionItems(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @RequestParam String q, @RequestParam(value = "cursor", required = false) LocalDateTime cursor) {
         return auctionItemService.searchAuctionItems(q, memberPrincipal.getId(), cursor);
+    }
+
+    @DeleteMapping("/{auctionItemId}")
+    public CommonResponse deleteAuctionItem(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @PathVariable Long auctionItemId) {
+        auctionItemService.deleteAuctionItem(memberPrincipal.getId(), auctionItemId);
+        return CommonResponse.success();
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/implement/AuctionItemStatusUpdater.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/implement/AuctionItemStatusUpdater.java
@@ -1,0 +1,25 @@
+package com.yzgeneration.evc.domain.item.auctionitem.implement;
+
+import com.yzgeneration.evc.domain.item.auctionitem.model.AuctionItem;
+import com.yzgeneration.evc.domain.item.auctionitem.service.port.AuctionItemRepository;
+import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
+import com.yzgeneration.evc.exception.CustomException;
+import com.yzgeneration.evc.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionItemStatusUpdater {
+    private final AuctionItemRepository auctionItemRepository;
+
+    public void updateItemStatus(Long memberId, Long auctionItemId, ItemStatus itemStatus) {
+        AuctionItem auctionItem = auctionItemRepository.getById(auctionItemId);
+        if (!auctionItem.getMemberId().equals(memberId)) {
+            throw new CustomException(ErrorCode.ITEM_ACCESS_DENIED);
+        }
+        auctionItem.updateItemStatus(itemStatus);
+        auctionItemRepository.save(auctionItem);
+    }
+
+}

--- a/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/infrastructure/entity/AuctionItemEntity.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/infrastructure/entity/AuctionItemEntity.java
@@ -50,6 +50,7 @@ public class AuctionItemEntity {
 
     public static AuctionItemEntity from(AuctionItem auctionItem) {
         return AuctionItemEntity.builder()
+                .id(auctionItem.getId())
                 .memberId(auctionItem.getMemberId())
                 .auctionItemDetailsEntity(AuctionItemDetailsEntity.from(auctionItem.getAuctionItemDetails()))
                 .transactionType(auctionItem.getTransactionType())

--- a/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/infrastructure/repository/AuctionItemRepositoryImpl.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/infrastructure/repository/AuctionItemRepositoryImpl.java
@@ -5,12 +5,12 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yzgeneration.evc.common.dto.SliceResponse;
 import com.yzgeneration.evc.domain.image.enums.ItemType;
-import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.AuctionItemPriceDetailResponse;
-import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
-import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetMyOrMemberAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemResponse.AuctionItemDetailsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemResponse.AuctionItemStatsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemResponse.GetAuctionItemResponse;
+import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.AuctionItemPriceDetailResponse;
+import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
+import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetMyOrMemberAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionParticipateResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.infrastructure.entity.AuctionItemEntity;
 import com.yzgeneration.evc.domain.item.auctionitem.model.AuctionItem;
@@ -172,7 +172,8 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepository {
                         .from(auctionItemEntity)
                         .join(memberEntity) //마켓 주인 닉네임 조회를 위해
                         .on(memberEntity.id.eq(auctionItemEntity.memberId))
-                        .where(auctionItemEntity.id.eq(id))
+                        .where(auctionItemEntity.id.eq(id)
+                                .and(auctionItemEntity.itemStatus.eq(ItemStatus.ACTIVE)))
                         .fetchOne())
                 .orElseThrow(
                         () -> new CustomException(ErrorCode.AUCTIONITEM_NOT_FOUND)
@@ -301,7 +302,8 @@ public class AuctionItemRepositoryImpl implements AuctionItemRepository {
     public Long countAuctionItemByMemberId(Long memberId) {
         return jpaQueryFactory.select(auctionItemEntity.count())
                 .from(auctionItemEntity)
-                .where(auctionItemEntity.memberId.eq(memberId))
+                .where(auctionItemEntity.memberId.eq(memberId)
+                        .and(auctionItemEntity.itemStatus.eq(ItemStatus.ACTIVE)))
                 .fetchOne();
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/model/AuctionItem.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/model/AuctionItem.java
@@ -43,11 +43,16 @@ public class AuctionItem {
                 .auctionItemDetails(AuctionItemDetails.create(createAuctionItemRequest))
                 .transactionType(TransactionType.valueOf(createAuctionItemRequest.getTransactionType()))
                 .transactionMode(TransactionMode.AUCTION)
+                .viewCount(0L)
                 .auctionItemPriceDetails(AuctionItemPriceDetails.create(createAuctionItemRequest))
                 .transactionStatus(TransactionStatus.ONGOING)
                 .itemStatus(ItemStatus.ACTIVE)
                 .startTime(now)
                 .endTime(now.plusDays(1))
                 .build();
+    }
+
+    public void updateItemStatus(ItemStatus itemStatus) {
+        this.itemStatus = itemStatus;
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/service/AuctionItemService.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/auctionitem/service/AuctionItemService.java
@@ -3,15 +3,17 @@ package com.yzgeneration.evc.domain.item.auctionitem.service;
 import com.yzgeneration.evc.common.dto.SliceResponse;
 import com.yzgeneration.evc.domain.image.enums.ItemType;
 import com.yzgeneration.evc.domain.image.implement.ItemImageAppender;
-import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemRequest.CreateAuctionItemRequest;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemResponse.GetAuctionItemResponse;
+import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetMyOrMemberAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.MyOrMemberAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.implement.AuctionItemReader;
+import com.yzgeneration.evc.domain.item.auctionitem.implement.AuctionItemStatusUpdater;
 import com.yzgeneration.evc.domain.item.auctionitem.model.AuctionItem;
 import com.yzgeneration.evc.domain.item.auctionitem.service.port.AuctionItemRepository;
 import com.yzgeneration.evc.domain.item.implement.ItemCounter;
+import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +26,7 @@ public class AuctionItemService {
     private final AuctionItemReader auctionItemReader;
     private final ItemImageAppender itemImageAppender;
     private final ItemCounter itemCounter;
+    private final AuctionItemStatusUpdater auctionItemStatusUpdater;
     private final ItemType itemType = ItemType.AUCTIONITEM;
 
     public void createAuctionItem(Long memberId, CreateAuctionItemRequest createAuctionItemRequest) {
@@ -47,6 +50,9 @@ public class AuctionItemService {
         Long postItemCount = itemCounter.countPostItem(memberId);
         SliceResponse<GetMyOrMemberAuctionItemsResponse> myOrMemberAuctionItems = auctionItemRepository.getMyOrMemberAuctionItems(memberId, cursor);
         return new MyOrMemberAuctionItemsResponse(postItemCount, myOrMemberAuctionItems);
+    }
 
+    public void deleteAuctionItem(Long memberId, Long auctionItemId) {
+        auctionItemStatusUpdater.updateItemStatus(memberId, auctionItemId, ItemStatus.DELETED);
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/controller/UsedItemController.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/controller/UsedItemController.java
@@ -2,9 +2,10 @@ package com.yzgeneration.evc.domain.item.useditem.controller;
 
 import com.yzgeneration.evc.common.dto.CommonResponse;
 import com.yzgeneration.evc.common.dto.SliceResponse;
-import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
+import com.yzgeneration.evc.domain.item.enums.TransactionStatus;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemRequest;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemResponse.GetUsedItemResponse;
+import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
 import com.yzgeneration.evc.domain.item.useditem.service.UsedItemService;
 import com.yzgeneration.evc.security.MemberPrincipal;
 import jakarta.validation.Valid;
@@ -39,5 +40,17 @@ public class UsedItemController {
     @GetMapping("/search")
     public SliceResponse<GetUsedItemsResponse> searchUsedItems(@RequestParam String q, @RequestParam(value = "cursor", required = false) LocalDateTime cursor) {
         return usedItemService.searchUsedItems(q, cursor);
+    }
+
+    @PatchMapping("/{usedItemId}")
+    public CommonResponse updateTransactionStatus(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @PathVariable Long usedItemId, @Valid @RequestParam TransactionStatus transactionStatus) {
+        usedItemService.updateTransactionStatus(memberPrincipal.getId(), usedItemId, transactionStatus);
+        return CommonResponse.success();
+    }
+
+    @DeleteMapping("/{usedItemId}")
+    public CommonResponse deleteUsedItem(@AuthenticationPrincipal MemberPrincipal memberPrincipal, @PathVariable Long usedItemId) {
+        usedItemService.deleteUsedItem(memberPrincipal.getId(), usedItemId);
+        return CommonResponse.success();
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/dto/UsedItemUpdateModeRequest.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/dto/UsedItemUpdateModeRequest.java
@@ -1,0 +1,25 @@
+package com.yzgeneration.evc.domain.item.useditem.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.yzgeneration.evc.domain.item.enums.TransactionMode;
+import com.yzgeneration.evc.validator.EnumValidator;
+import com.yzgeneration.evc.validator.Validatable;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UsedItemUpdateModeRequest implements Validatable {
+
+    @NotBlank
+    private String transactionMode;
+
+    public UsedItemUpdateModeRequest(String transactionMode) {
+        this.transactionMode = transactionMode;
+        valid();
+    }
+
+    @Override
+    public void valid() {
+        EnumValidator.validate(TransactionMode.class, "transactionMode", transactionMode);
+    }
+}

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/implement/UsedItemStatusUpdater.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/implement/UsedItemStatusUpdater.java
@@ -1,0 +1,38 @@
+package com.yzgeneration.evc.domain.item.useditem.implement;
+
+import com.yzgeneration.evc.domain.item.enums.TransactionStatus;
+import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
+import com.yzgeneration.evc.domain.item.useditem.model.UsedItem;
+import com.yzgeneration.evc.domain.item.useditem.service.port.UsedItemRepository;
+import com.yzgeneration.evc.exception.CustomException;
+import com.yzgeneration.evc.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UsedItemStatusUpdater {
+    private final UsedItemRepository usedItemRepository;
+
+    public void updateTransactionStatus(Long memberId, Long usedItemId, TransactionStatus transactionStatus) {
+        UsedItem usedItem = usedItemRepository.getById(usedItemId);
+
+        if (!usedItem.getMemberId().equals(memberId)) {
+            throw new CustomException(ErrorCode.ITEM_ACCESS_DENIED);
+        }
+        usedItem.updateTransactionStatus(transactionStatus);
+        usedItemRepository.save(usedItem);
+    }
+
+    public void updateItemStatus(Long memberId, Long usedItemId, ItemStatus itemStatus) {
+        UsedItem usedItem = usedItemRepository.getById(usedItemId);
+
+        if (!usedItem.getMemberId().equals(memberId)) {
+            throw new CustomException(ErrorCode.ITEM_ACCESS_DENIED);
+        }
+        usedItem.updateItemStatus(itemStatus); //sofe delete 적용
+        usedItemRepository.save(usedItem);
+    }
+}

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/infrastructure/entity/UsedItemEntity.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/infrastructure/entity/UsedItemEntity.java
@@ -36,6 +36,7 @@ public class UsedItemEntity {
 
     public static UsedItemEntity from(UsedItem usedItem) {
         return UsedItemEntity.builder()
+                .id(usedItem.getId())
                 .memberId(usedItem.getMemberId())
                 .itemDetailsEntity(ItemDetailsEntity.from(usedItem.getItemDetails()))
                 .usedItemTransactionEntity(UsedItemTransactionEntity.from(usedItem.getUsedItemTransaction()))

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/infrastructure/repository/UsedItemRepositoryImpl.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/infrastructure/repository/UsedItemRepositoryImpl.java
@@ -8,9 +8,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yzgeneration.evc.common.dto.SliceResponse;
 import com.yzgeneration.evc.domain.image.enums.ItemType;
 import com.yzgeneration.evc.domain.item.enums.TransactionMode;
+import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemResponse.GetUsedItemResponse;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetMyOrMemberUsedItemsResponse;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
-import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemResponse.GetUsedItemResponse;
 import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
 import com.yzgeneration.evc.domain.item.useditem.infrastructure.entity.UsedItemEntity;
 import com.yzgeneration.evc.domain.item.useditem.model.UsedItem;
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -154,7 +155,8 @@ public class UsedItemRepositoryImpl implements UsedItemRepository {
                 .from(usedItemEntity)
                 .join(memberEntity)
                 .on(memberEntity.id.eq(usedItemEntity.memberId))
-                .where(usedItemEntity.id.eq(usedItemId))
+                .where(usedItemEntity.id.eq(usedItemId)
+                        .and(usedItemEntity.itemStatus.eq(ItemStatus.ACTIVE)))
                 .fetchFirst();
 
         return Optional.ofNullable(usedItemResponse);
@@ -212,7 +214,8 @@ public class UsedItemRepositoryImpl implements UsedItemRepository {
     public Long countUsedItemByMemberId(Long memberId) {
         return jpaQueryFactory.select(usedItemEntity.count())
                 .from(usedItemEntity)
-                .where(usedItemEntity.memberId.eq(memberId))
+                .where(usedItemEntity.memberId.eq(memberId)
+                        .and(usedItemEntity.itemStatus.eq(ItemStatus.ACTIVE)))
                 .fetchOne();
     }
 

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/model/ItemStats.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/model/ItemStats.java
@@ -14,6 +14,10 @@ public class ItemStats {
     private Long chattingCount;
 
     public static ItemStats create() {
-        return ItemStats.builder().build();
+        return ItemStats.builder()
+                .viewCount(0L)
+                .likeCount(0L)
+                .chattingCount(0L)
+                .build();
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/model/UsedItem.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/model/UsedItem.java
@@ -1,5 +1,6 @@
 package com.yzgeneration.evc.domain.item.useditem.model;
 
+import com.yzgeneration.evc.domain.item.enums.TransactionStatus;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemRequest.CreateUsedItemRequest;
 import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
 import lombok.Builder;
@@ -34,5 +35,13 @@ public class UsedItem {
                 .itemStats(ItemStats.create())
                 .createdAt(createAt)
                 .build();
+    }
+
+    public void updateTransactionStatus(TransactionStatus transactionMode) {
+        this.usedItemTransaction.updateTransactionStatus(transactionMode);
+    }
+
+    public void updateItemStatus(ItemStatus itemStatus){
+        this.itemStatus = itemStatus;
     }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/model/UsedItemTransaction.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/model/UsedItemTransaction.java
@@ -24,4 +24,8 @@ public class UsedItemTransaction {
                 .transactionStatus(TransactionStatus.ONGOING)
                 .build();
     }
+
+    public void updateTransactionStatus(TransactionStatus transactionStatus) {
+        this.transactionStatus = transactionStatus;
+    }
 }

--- a/src/main/java/com/yzgeneration/evc/domain/item/useditem/service/UsedItemService.java
+++ b/src/main/java/com/yzgeneration/evc/domain/item/useditem/service/UsedItemService.java
@@ -4,13 +4,16 @@ import com.yzgeneration.evc.common.dto.SliceResponse;
 import com.yzgeneration.evc.domain.image.enums.ItemType;
 import com.yzgeneration.evc.domain.image.implement.ItemImageAppender;
 import com.yzgeneration.evc.domain.item.enums.TransactionMode;
+import com.yzgeneration.evc.domain.item.enums.TransactionStatus;
 import com.yzgeneration.evc.domain.item.implement.ItemCounter;
 import com.yzgeneration.evc.domain.item.useditem.dto.MyOrMemberUsedItemsResponse;
-import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetMyOrMemberUsedItemsResponse;
-import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemRequest.CreateUsedItemRequest;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemResponse.GetUsedItemResponse;
+import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetMyOrMemberUsedItemsResponse;
+import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
+import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
 import com.yzgeneration.evc.domain.item.useditem.implement.UsedItemReader;
+import com.yzgeneration.evc.domain.item.useditem.implement.UsedItemStatusUpdater;
 import com.yzgeneration.evc.domain.item.useditem.model.UsedItem;
 import com.yzgeneration.evc.domain.item.useditem.service.port.UsedItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,7 @@ public class UsedItemService {
     private final ItemImageAppender itemImageAppender;
     private final UsedItemReader usedItemReader;
     private final ItemCounter itemCounter;
+    private final UsedItemStatusUpdater usedItemStatusUpdater;
 
     private final ItemType itemType = ItemType.USEDITEM;
 
@@ -50,5 +54,13 @@ public class UsedItemService {
         Long postItemCount = itemCounter.countPostItem(memberId);
         SliceResponse<GetMyOrMemberUsedItemsResponse> myOrMemberUsedItems = usedItemRepository.getMyOrMemberUsedItems(memberId, cursor, transactionMode);
         return new MyOrMemberUsedItemsResponse(postItemCount, myOrMemberUsedItems);
+    }
+
+    public void updateTransactionStatus(Long memberId, Long usedItemId, TransactionStatus transactionStatus) {
+        usedItemStatusUpdater.updateTransactionStatus(memberId, usedItemId, transactionStatus);
+    }
+
+    public void deleteUsedItem(Long memberId, Long usedItemId) {
+        usedItemStatusUpdater.updateItemStatus(memberId, usedItemId, ItemStatus.DELETED);
     }
 }

--- a/src/main/java/com/yzgeneration/evc/exception/ErrorCode.java
+++ b/src/main/java/com/yzgeneration/evc/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
 
     //403 Forbidden
     INACTIVE_MEMBER(HttpStatus.FORBIDDEN, "031", "비활성화 된 계정입니다."),
+    ITEM_ACCESS_DENIED(HttpStatus.FORBIDDEN, "032", "본인의 물품의 상태만 수정할 수 있습니다."),
 
     //404 NotFound
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "041", "해당 회원이 존재하지 않습니다."),

--- a/src/test/java/com/yzgeneration/evc/auctionitem/service/AuctionItemServiceTest.java
+++ b/src/test/java/com/yzgeneration/evc/auctionitem/service/AuctionItemServiceTest.java
@@ -3,10 +3,11 @@ package com.yzgeneration.evc.auctionitem.service;
 import com.yzgeneration.evc.common.dto.SliceResponse;
 import com.yzgeneration.evc.domain.image.implement.ItemImageAppender;
 import com.yzgeneration.evc.domain.image.service.port.ItemImageRepository;
-import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemRequest.CreateAuctionItemRequest;
 import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemResponse.GetAuctionItemResponse;
+import com.yzgeneration.evc.domain.item.auctionitem.dto.AuctionItemsResponse.GetAuctionItemsResponse;
 import com.yzgeneration.evc.domain.item.auctionitem.implement.AuctionItemReader;
+import com.yzgeneration.evc.domain.item.auctionitem.implement.AuctionItemStatusUpdater;
 import com.yzgeneration.evc.domain.item.auctionitem.service.AuctionItemService;
 import com.yzgeneration.evc.domain.item.auctionitem.service.port.AuctionItemRepository;
 import com.yzgeneration.evc.domain.item.implement.ItemCounter;
@@ -32,8 +33,9 @@ public class AuctionItemServiceTest {
         ItemImageAppender itemImageAppender = new ItemImageAppender(itemImageRepository);
         AuctionItemReader auctionItemReader = new AuctionItemReader(auctionItemRepository, itemImageRepository);
         ItemCounter itemCounter = new ItemCounter(usedItemRepository, auctionItemRepository);
+        AuctionItemStatusUpdater auctionItemStatusUpdater = new AuctionItemStatusUpdater(auctionItemRepository);
 
-        auctionItemService = new AuctionItemService(auctionItemRepository, auctionItemReader, itemImageAppender, itemCounter);
+        auctionItemService = new AuctionItemService(auctionItemRepository, auctionItemReader, itemImageAppender, itemCounter, auctionItemStatusUpdater);
     }
 
     @Test

--- a/src/test/java/com/yzgeneration/evc/docs/auctionitem/AuctionItemControllerDocsTest.java
+++ b/src/test/java/com/yzgeneration/evc/docs/auctionitem/AuctionItemControllerDocsTest.java
@@ -137,7 +137,7 @@ public class AuctionItemControllerDocsTest extends RestDocsSupport {
     @DisplayName("경매상품 조회")
     void getAuctionItem() throws Exception {
 
-        AuctionItemDetailsResponse auctionItemDetailsResponse = new AuctionItemDetailsResponse("title",  "category", "content");
+        AuctionItemDetailsResponse auctionItemDetailsResponse = new AuctionItemDetailsResponse("title", "category", "content");
         AuctionItemStatsResponse auctionItemStatsResponse = new AuctionItemStatsResponse(1L, 1L, 1L);
         List<String> imageNameList = List.of("imageName.jpg");
         GetAuctionItemResponse getAuctionItemResponse = new GetAuctionItemResponse(auctionItemDetailsResponse, auctionItemStatsResponse, imageNameList, TransactionType.DIRECT, LocalDateTime.MIN, LocalDateTime.MIN.plusDays(1), 5000, 1L, "marketNickname", false, ItemStatus.ACTIVE);
@@ -239,6 +239,21 @@ public class AuctionItemControllerDocsTest extends RestDocsSupport {
                                         .description("조회된 데이터 개수"),
                                 fieldWithPath("cursor").type(JsonFieldType.STRING)
                                         .description("다음 페이지 커서")
+                        )));
+    }
+
+    @Test
+    @DisplayName("경매상품 삭제")
+    void deleteAuctionItem() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/auctionitems/{auctionItemId}", 1L))
+                .andExpect(status().isOk())
+                .andDo(document("auctionitem-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(parameterWithName("auctionItemId").description("경매상품의 id")),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                                        .description("성공여부")
                         )));
     }
 }

--- a/src/test/java/com/yzgeneration/evc/docs/usedItem/UsedItemControllerDocsTest.java
+++ b/src/test/java/com/yzgeneration/evc/docs/usedItem/UsedItemControllerDocsTest.java
@@ -6,9 +6,9 @@ import com.yzgeneration.evc.domain.item.enums.TransactionMode;
 import com.yzgeneration.evc.domain.item.enums.TransactionStatus;
 import com.yzgeneration.evc.domain.item.enums.TransactionType;
 import com.yzgeneration.evc.domain.item.useditem.controller.UsedItemController;
-import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemRequest.CreateUsedItemRequest;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemResponse.GetUsedItemResponse;
+import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedItemsResponse;
 import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
 import com.yzgeneration.evc.domain.item.useditem.service.UsedItemService;
 import org.junit.jupiter.api.DisplayName;
@@ -52,7 +52,7 @@ public class UsedItemControllerDocsTest extends RestDocsSupport {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andDo(document("usedItem-create",
+                .andDo(document("useditem-create",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestFields(
@@ -90,7 +90,7 @@ public class UsedItemControllerDocsTest extends RestDocsSupport {
                         .get("/api/useditems")
                         .param("cursor", LocalDateTime.MIN.toString()))
                 .andExpect(status().isOk())
-                .andDo(document("usedItems-get",
+                .andDo(document("useditems-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         queryParameters(parameterWithName("cursor").description("이전 메시지 조회를 위한 커서 (ISO-8601 형식: yyyy-MM-dd'T'HH:mm:ss)")),
@@ -154,7 +154,7 @@ public class UsedItemControllerDocsTest extends RestDocsSupport {
         mockMvc.perform(MockMvcRequestBuilders
                         .get("/api/useditems/{usedItemId}", 1L))
                 .andExpect(status().isOk())
-                .andDo(document("usedItem-get",
+                .andDo(document("useditem-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(parameterWithName("usedItemId").description("중고상품의 id")),
@@ -208,7 +208,7 @@ public class UsedItemControllerDocsTest extends RestDocsSupport {
                         .param("q", "query")
                         .param("cursor", LocalDateTime.MIN.toString()))
                 .andExpect(status().isOk())
-                .andDo(document("usedItems-search",
+                .andDo(document("useditems-search",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         queryParameters(
@@ -243,6 +243,38 @@ public class UsedItemControllerDocsTest extends RestDocsSupport {
                                         .description("조회된 데이터 개수"),
                                 fieldWithPath("cursor").type(JsonFieldType.STRING)
                                         .description("다음 페이지 커서")
+                        )));
+    }
+
+    @Test
+    @DisplayName("중고상품의 transaction status 변경")
+    void updateUsedItemTransactionStatus() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.patch("/api/useditems/{usedItemId}", 1L)
+                        .queryParam("transactionStatus", TransactionStatus.RESERVE.name()))
+                .andExpect(status().isOk())
+                .andDo(document("useditem-transactionstatus-update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(parameterWithName("usedItemId").description("중고상품의 id")),
+                        queryParameters(parameterWithName("transactionStatus").description("변경할 Transaction Status (ONGOING, RESERVE, COMPLETE)")),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                                        .description("성공여부")
+                        )));
+    }
+
+    @Test
+    @DisplayName("중고상품 삭제")
+    void deleteAuctionItem() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/useditems/{usedItemId}", 1L))
+                .andExpect(status().isOk())
+                .andDo(document("useditem-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(parameterWithName("usedItemId").description("중고상품의 id")),
+                        responseFields(
+                                fieldWithPath("success").type(JsonFieldType.BOOLEAN)
+                                        .description("성공여부")
                         )));
     }
 }

--- a/src/test/java/com/yzgeneration/evc/mock/usedItem/FakeUsedItemRepository.java
+++ b/src/test/java/com/yzgeneration/evc/mock/usedItem/FakeUsedItemRepository.java
@@ -95,4 +95,5 @@ public class FakeUsedItemRepository implements UsedItemRepository {
     public Long countUsedItemByMemberId(Long memberId) {
         return null;
     }
+
 }

--- a/src/test/java/com/yzgeneration/evc/usedItem/service/UsedItemServiceTest.java
+++ b/src/test/java/com/yzgeneration/evc/usedItem/service/UsedItemServiceTest.java
@@ -12,6 +12,7 @@ import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemsResponse.GetUsedIt
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemRequest.CreateUsedItemRequest;
 import com.yzgeneration.evc.domain.item.useditem.dto.UsedItemResponse.GetUsedItemResponse;
 import com.yzgeneration.evc.domain.item.useditem.enums.ItemStatus;
+import com.yzgeneration.evc.domain.item.useditem.implement.UsedItemStatusUpdater;
 import com.yzgeneration.evc.domain.item.useditem.implement.UsedItemReader;
 import com.yzgeneration.evc.domain.item.useditem.service.UsedItemService;
 import com.yzgeneration.evc.domain.item.useditem.service.port.UsedItemRepository;
@@ -35,8 +36,9 @@ class UsedItemServiceTest {
         UsedItemReader usedItemReader = new UsedItemReader(usedItemRepository, itemImageRepository);
         ItemImageAppender itemImageAppender = new ItemImageAppender(itemImageRepository);
         ItemCounter itemCounter = new ItemCounter(usedItemRepository, auctionItemRepository);
+        UsedItemStatusUpdater usedItemStatusUpdater = new UsedItemStatusUpdater(usedItemRepository);
 
-        usedItemService = new UsedItemService(usedItemRepository, itemImageAppender, usedItemReader, itemCounter);
+        usedItemService = new UsedItemService(usedItemRepository, itemImageAppender, usedItemReader, itemCounter, usedItemStatusUpdater);
     }
 
     @Test


### PR DESCRIPTION
### 🔅 이슈번호
close #201 

---

### ⏰ 작업한 내용
- 중고상품의 거래 상태 수정 (TransactionStatus값 변경)
- 중고상품 삭제
- 경매상품 삭제

---

### ⌛️ 스크린샷 (Optional)
![image](https://github.com/user-attachments/assets/3787d8e4-ba88-4df0-a9dc-3a16af518e9b)
<i>중고상품 거래상태 수정</i>

![image](https://github.com/user-attachments/assets/6122a438-bff7-4531-b7b8-1856782c27ba)
<i>중고상품 삭제</i>

![image](https://github.com/user-attachments/assets/2ff74533-989a-4de6-8925-9bf3ca3c57bc)
<i>경매상품 삭제</i>